### PR TITLE
Extend compatibility to Ruby 3

### DIFF
--- a/lib/rubocop/inflector/version.rb
+++ b/lib/rubocop/inflector/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Inflector
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/rubocop-inflector.gemspec
+++ b/rubocop-inflector.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'RuboCop extension to integrate ActiveSupport::Inflector'
   spec.description   = 'RuboCop extension to integrate ActiveSupport::Inflector'
-  spec.homepage      = 'https://github.com/splitwise/rubocop-inflector'
+  spec.homepage      = 'https://github.com/aeroastro/rubocop-inflector'
   spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = ['>= 2.3', '< 4']
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'rubocop'

--- a/rubocop-inflector.gemspec
+++ b/rubocop-inflector.gemspec
@@ -7,12 +7,12 @@ require 'rubocop/inflector/version'
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-inflector'
   spec.version       = RuboCop::Inflector::VERSION
-  spec.authors       = ['Takumasa Ochi']
-  spec.email         = ['aeroastro007@gmail.com']
+  spec.authors       = ['Takumasa Ochi', 'Dylan Rainwater']
+  spec.email         = ['aeroastro007@gmail.com', 'support@splitwise.com']
 
   spec.summary       = 'RuboCop extension to integrate ActiveSupport::Inflector'
   spec.description   = 'RuboCop extension to integrate ActiveSupport::Inflector'
-  spec.homepage      = 'https://github.com/aeroastro/rubocop-inflector'
+  spec.homepage      = 'https://github.com/splitwise/rubocop-inflector'
   spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'

--- a/rubocop-inflector.gemspec
+++ b/rubocop-inflector.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 3.0'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'rubocop'

--- a/rubocop-inflector.gemspec
+++ b/rubocop-inflector.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '~> 3.0'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'rubocop'


### PR DESCRIPTION
👋

This gem is still useful but hasn't been updated to support Ruby 3 yet. The gemspec just needs to be updated to allow Ruby 3 projects to include `rubocop-inflector`, the code for the gem itself seems fine without any further changes. Thanks!