### PR TITLE
Version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Changes
 
-## 0.2.0 (2022-04-12)
+## 0.2.1 (2022-04-12)
+
+* Increment minor version respecting semantic versioning. No changes are included except version number. ([Takumasa Ochi](@aeroastro))
+
+## 0.1.2 (2022-04-12)
 
 ### Changes
 

--- a/lib/rubocop/inflector/version.rb
+++ b/lib/rubocop/inflector/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Inflector
-    VERSION = '0.1.2'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
As the supporting Ruby version has been changed, I would like to increment the minor version of this gem.
In order to prevent mistakes, I would like to use this Pull Request for releasing procedures.

Ruby 3 support is included both in 0.1.2 and 0.2.1. The only difference between these two versions is just the version number.