### PR TITLE
Add support for `RSpec/SpecFilePathFormat` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 
+* Support `RSpec/SpecFilePathFormat` cop ([Ryo Maeda](@epaew))
+
 ### Bug fixes
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Now you can run `rubocop` and it will automatically integrate ActiveSupport Inte
 Following cops and logics are now supported.
 
 * `RSpec/FilePath`
+* `RSpec/SpecFilePathFormat`
 
 ## Development
 

--- a/lib/rubocop/inflector/extensions/rspec.rb
+++ b/lib/rubocop/inflector/extensions/rspec.rb
@@ -12,10 +12,21 @@ module RuboCop
                 ActiveSupport::Inflector.underscore(string)
               end
             end
+
+            module SpecFilePathFormat
+              def camel_to_snake_case(string)
+                ActiveSupport::Inflector.underscore(string)
+              end
+            end
           end
         end
 
-        ::RuboCop::Cop::RSpec::FilePath.prepend Cop::RSpec::FilePath
+        if const_defined? '::RuboCop::Cop::RSpec::FilePath'
+          ::RuboCop::Cop::RSpec::FilePath.prepend Cop::RSpec::FilePath
+        end
+        if const_defined? '::RuboCop::Cop::RSpec::SpecFilePathFormat'
+          ::RuboCop::Cop::RSpec::SpecFilePathFormat.prepend Cop::RSpec::SpecFilePathFormat
+        end
       end
     end
   end

--- a/spec/rubocop/inflector/extensions/rspec_spec.rb
+++ b/spec/rubocop/inflector/extensions/rspec_spec.rb
@@ -1,35 +1,72 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Inflector::Extensions::RSpec do
-  describe RuboCop::Cop::RSpec::FilePath, :config do
-    subject(:cop) { described_class.new(config) }
+  if const_defined? 'RuboCop::Cop::RSpec::FilePath'
+    describe RuboCop::Cop::RSpec::FilePath, :config do
+      subject(:cop) { described_class.new(config) }
 
-    context 'without ActiveSupport::Inflector config' do
-      it 'registers an offense for a bad path' do
-        expect_offense(<<~RUBY, 'wrong_path_foo_spec.rb')
-          describe MyClass, 'foo' do; end
-          ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
-        RUBY
-      end
+      context 'without ActiveSupport::Inflector config' do
+        it 'registers an offense for a bad path' do
+          expect_offense(<<~RUBY, 'wrong_path_foo_spec.rb')
+            describe MyClass, 'foo' do; end
+            ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+          RUBY
+        end
 
-      it 'checks class specs' do
-        expect_no_offenses(<<~RUBY, 'some/class_spec.rb')
-          describe Some::Class do; end
-        RUBY
-      end
-    end
-
-    context 'with ActiveSupport::Inflector config' do
-      before do
-        ActiveSupport::Inflector.inflections(:en) do |inflect|
-          inflect.acronym 'PvP'
+        it 'checks class specs' do
+          expect_no_offenses(<<~RUBY, 'some/class_spec.rb')
+            describe Some::Class do; end
+          RUBY
         end
       end
 
-      it 'checks class specs with registered acronym' do
-        expect_no_offenses(<<~RUBY, 'pvp/pvp_battles_controller_spec.rb')
-          describe PvP::PvPBattlesController do; end
-        RUBY
+      context 'with ActiveSupport::Inflector config' do
+        before do
+          ActiveSupport::Inflector.inflections(:en) do |inflect|
+            inflect.acronym 'PvP'
+          end
+        end
+
+        it 'checks class specs with registered acronym' do
+          expect_no_offenses(<<~RUBY, 'pvp/pvp_battles_controller_spec.rb')
+            describe PvP::PvPBattlesController do; end
+          RUBY
+        end
+      end
+    end
+  end
+
+  if const_defined? 'RuboCop::Cop::RSpec::SpecFilePathFormat'
+    describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
+      subject(:cop) { described_class.new(config) }
+
+      context 'without ActiveSupport::Inflector config' do
+        it 'registers an offense for a bad path' do
+          expect_offense(<<~RUBY, 'wrong_path_foo_spec.rb')
+            describe MyClass, 'foo' do; end
+            ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+          RUBY
+        end
+
+        it 'checks class specs' do
+          expect_no_offenses(<<~RUBY, 'some/class_spec.rb')
+            describe Some::Class do; end
+          RUBY
+        end
+      end
+
+      context 'with ActiveSupport::Inflector config' do
+        before do
+          ActiveSupport::Inflector.inflections(:en) do |inflect|
+            inflect.acronym 'PvP'
+          end
+        end
+
+        it 'checks class specs with registered acronym' do
+          expect_no_offenses(<<~RUBY, 'pvp/pvp_battles_controller_spec.rb')
+            describe PvP::PvPBattlesController do; end
+          RUBY
+        end
       end
     end
   end


### PR DESCRIPTION
In RuboCop RSpec v2.24.0, `RSpec/SpecFilePathFormat` cop was introduced and `RSpec/FilePath` cop was deprecated (splitted).

* https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0

So I added support for the newly introduced cop. Please consider merging!
