### PR TITLE
Fix failing tests with newer RuboCop RSpec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
-before_install: gem install bundler -v 1.16.2
+  - '2.6'
+  - '2.7'
+  - '3.0'
+  - '3.1'
+  - '3.2'
+before_install: gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changes
 
+* Drop support for Ruby < 2.6 ([Ryo Maeda](@epaew))
+
 ## 0.2.1 (2022-04-12)
 
 * Increment minor version respecting semantic versioning. No changes are included except version number. ([Takumasa Ochi](@aeroastro))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+* Fix failing tests with newer version of RuboCop RSpec ([Ryo Maeda](@epaew))
+
 ### Changes
 
 * Drop support for Ruby < 2.6 ([Ryo Maeda](@epaew))

--- a/rubocop-inflector.gemspec
+++ b/rubocop-inflector.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'rubocop'
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop-rspec', '>= 2.15'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'bundler/setup'
 require 'rubocop-rspec'
 require 'rubocop-inflector'
 
+require 'rubocop/rspec/shared_contexts/default_rspec_language_config_context' # from rubocop-rspec
 require 'rubocop/rspec/support'
 
 if ENV['COVERAGE'] == 'true'
@@ -36,6 +37,8 @@ RSpec.configure do |config|
   config.raise_on_warning = true
 
   config.include(RuboCop::RSpec::ExpectOffense)
+
+  config.include_context 'with default RSpec/Language config', :config
 
   # Initialize ActiveSupport::Inflector
   config.before do


### PR DESCRIPTION
When I tried to create #5, I noticed that the tests were not passing.

Apparently, using RuboCop RSpec that is too new causes the tests to fail.

I fixed the test so that it passes even when using the latest version of RuboCop RSpec.