### PR TITLE
Add spelling checks to the workflow in GitHub Actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,18 @@
+name: CodeSpell
+on:
+  - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          check_hidden: true
+          ignore_words_file: .codespellignore

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: CodeSpell
-        uses: codespell-project/actions-codespell@master
+        uses: codespell-project/actions-codespell@v2
         with:
           check_filenames: true
           check_hidden: true

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gem 'rubocop-inflector'
 ## Usage
 
 You need to tell RuboCop to load the Inflector extension and your custom ActiveSupport::Inflector rule.
-Custom rule file would be the followings. If you are using Rails, you can find it under `config` directory.
+Custom rule file would be the following. If you are using Rails, you can find it under `config` directory.
 
 ### Custom ActiveSupport::Inflector rule
 


### PR DESCRIPTION
We would like to leave it to codespell to verify the spelling of our code.

I propose to use codespell-project/actions-codespell, now v1.0.
https://github.com/codespell-project/actions-codespell
