### PR TITLE
Loosen development dependencies for gemspec

### DIFF
--- a/rubocop-inflector.gemspec
+++ b/rubocop-inflector.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rake', '>= 10'
+  spec.add_development_dependency 'rspec', '>= 3'
   spec.add_development_dependency 'rubocop-rspec', '>= 2.15'
 end


### PR DESCRIPTION
The reasons are the follows.

* In order to stop errors with latest ruby.
* In order to ease updating processes